### PR TITLE
Add Service in order to generate correct NetworkPolicies

### DIFF
--- a/charts/gardener-extension-backup-s3/templates/service.yaml
+++ b/charts/gardener-extension-backup-s3/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
+    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: extensions
+{{- if .Values.ignoreResources }}
+    resources.gardener.cloud/ignore: "true"
+{{- end }}
+  labels:
+{{ include "labels" . | indent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+{{ include "labels" . | indent 6 }}
+  ports:
+  - name: metrics
+    port: {{ .Values.metricsPort }}
+    targetPort: {{ .Values.metricsPort }}
+    protocol: TCP


### PR DESCRIPTION
## Description
The extension is discovered by the `PodMonitor/seed-extensions`, but cannot be scraped by `seed-prometheus` because there are no ingress NetworkPolicies that allow it. 

This PR adds the Service in accordance with the [gardener documentation](https://gardener.cloud/docs/gardener/network_policies/#seed-system-namespaces) 

## Release Notes

### Noteworthy

```NOTEWORTHY
The extension now deploys a `Service` and can be scraped by seed-prometheus.
```
