### PR TITLE
improve resource naming of chart by using fullname rather than the static gardener-extension-backup-s3

### DIFF
--- a/charts/gardener-extension-backup-s3/templates/_helpers.tpl
+++ b/charts/gardener-extension-backup-s3/templates/_helpers.tpl
@@ -1,18 +1,51 @@
 {{- define "name" -}}
-gardener-extension-backup-s3
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
-{{- define "labels.app.key" -}}
-app.kubernetes.io/name
-{{- end -}}
-{{- define "labels.app.value" -}}
-{{ include "name" . }}
-{{- end -}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
-{{- define "labels" -}}
-{{ include "labels.app.key" . }}: {{ include "labels.app.value" . }}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "selectorLabels" -}}
+app.kubernetes.io/name: {{ include "name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels" -}}
+helm.sh/chart: {{ include "chart" . }}
+{{ include "selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 
 {{-  define "image" -}}
   {{- if hasPrefix "sha256:" .Values.image.tag }}

--- a/charts/gardener-extension-backup-s3/templates/configmap.yaml
+++ b/charts/gardener-extension-backup-s3/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "name" . }}-configmap
+  name: {{ include "fullname" . }}-configmap
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 data:
   config.yaml: |
     ---

--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{-  if .Values.ignoreResources }}
   annotations:
     resources.gardener.cloud/ignore: "true"
 {{- end }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
   high-availability-config.resources.gardener.cloud/type: server
 spec:
   revisionHistoryLimit: 0
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-{{ include "labels" . | indent 6 }}
+      {{- include "selectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxUnavailable: {{ .Values.maxUnavailable }}
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap-{{ include "name" . }}-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/configmap-{{ include "fullname" . }}-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if and .Values.metrics.enableScraping }}
         prometheus.io/name: "{{ .Release.Name }}"
         prometheus.io/scrape: "true"
@@ -36,14 +36,14 @@ spec:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-private-networks: allowed
         networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443: allowed
-{{ include "labels" . | indent 8 }}
+        {{- include "selectorLabels" . | nindent 8 }}
     spec:
       {{- if (include "runtimeCluster.enabled" .) }}
       priorityClassName: {{ .Values.gardener.runtimeCluster.priorityClassName }}
       {{- else }}
       priorityClassName: gardener-system-900
       {{- end }}
-      serviceAccountName: {{ include "name" . }}
+      serviceAccountName: {{ include "fullname" . }}
       containers:
       - name: {{ include "name" . }}
         image: {{ include "image" . }}
@@ -94,5 +94,5 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "name" . }}-configmap
+          name: {{ include "fullname" . }}-configmap
           defaultMode: 420

--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap-{{ include "fullname" . }}-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/configmap-{{ include "name" . }}-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if and .Values.metrics.enableScraping }}
         prometheus.io/name: "{{ .Release.Name }}"
         prometheus.io/scrape: "true"

--- a/charts/gardener-extension-backup-s3/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-backup-s3/templates/poddisruptionbudget.yaml
@@ -1,15 +1,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-{{ include "labels" . | indent 6 }}
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
+      {{- include "selectorLabels" . | nindent 6 }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/gardener-extension-backup-s3/templates/rbac.yaml
+++ b/charts/gardener-extension-backup-s3/templates/rbac.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - extensions.gardener.cloud
@@ -132,14 +132,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/gardener-extension-backup-s3/templates/service.yaml
+++ b/charts/gardener-extension-backup-s3/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
@@ -11,11 +11,11 @@ metadata:
     resources.gardener.cloud/ignore: "true"
 {{- end }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:
-{{ include "labels" . | indent 6 }}
+    {{- include "selectorLabels" . | nindent 6 }}
   ports:
   - name: metrics
     port: {{ .Values.metricsPort }}

--- a/charts/gardener-extension-backup-s3/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-backup-s3/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "name" . }}
+  name: {{ include "fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "labels" . | indent 4 }}
+    {{- include "labels" . | nindent 4 }}
 automountServiceAccountToken: false

--- a/charts/gardener-extension-backup-s3/values.yaml
+++ b/charts/gardener-extension-backup-s3/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 image:
   repository: ghcr.io/metal-stack/gardener-extension-backup-s3
   tag: latest


### PR DESCRIPTION
## Description

When installing the chart twice in the same cluster, you can get 2 MR's fighting for the same resources as they are named exactly the same. This PR changes this behavior and allows the operator to either set a nameOverride or use the much more reliable `.Release.Name` for everything which should reduce the chance of things clashing.

## Release Notes

### Noteworthy

```NOTEWORTHY
```
