### PR TITLE
Harden deployment to comply with pod security standard "restricted"

### DIFF
--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
           runAsNonRoot: true
           runAsUser: 65532
           runAsGroup: 65532
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - name: config
           mountPath: /etc/{{ include "name" . }}/config

--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -88,9 +88,18 @@ spec:
         resources:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1337
+          runAsGroup: 1337
         volumeMounts:
         - name: config
           mountPath: /etc/{{ include "name" . }}/config
+          readOnly: true
       volumes:
       - name: config
         configMap:

--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -94,8 +94,8 @@ spec:
             drop: [ "ALL" ]
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1337
-          runAsGroup: 1337
+          runAsUser: 65532
+          runAsGroup: 65532
         volumeMounts:
         - name: config
           mountPath: /etc/{{ include "name" . }}/config


### PR DESCRIPTION
## Description

Add a strict securityContext to the deployment and make the config mount readonly. 

The values are selected to comply with [PSS restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/). The RuntimeDefault seccomp profile is already automatically injected by Gardener.

Related to https://github.com/gardener/gardener/issues/12658