### PR TITLE
fix(charts): wrong serviceAccount reference in rbac-runtime

### DIFF
--- a/charts/gardener-extension-backup-s3/templates/deployment.yaml
+++ b/charts/gardener-extension-backup-s3/templates/deployment.yaml
@@ -40,10 +40,11 @@ spec:
     spec:
       {{- if (include "runtimeCluster.enabled" .) }}
       priorityClassName: {{ .Values.gardener.runtimeCluster.priorityClassName }}
+      serviceAccountName: {{ include "name" . }}-runtime
       {{- else }}
       priorityClassName: gardener-system-900
-      {{- end }}
       serviceAccountName: {{ include "fullname" . }}
+      {{- end }}
       containers:
       - name: {{ include "name" . }}
         image: {{ include "image" . }}

--- a/charts/gardener-extension-backup-s3/templates/rbac-runtime.yaml
+++ b/charts/gardener-extension-backup-s3/templates/rbac-runtime.yaml
@@ -75,6 +75,6 @@ roleRef:
   name: {{ include "name" . }}-runtime
 subjects:
 - kind: ServiceAccount
-  name: {{ include "name" . }}
+  name: {{ include "name" . }}-runtime
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/gardener-extension-backup-s3/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-backup-s3/templates/serviceaccount.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if (include "runtimeCluster.enabled" .) }}
+  name: {{ include "name" . }}-runtime
+  {{- else }}
   name: {{ include "fullname" . }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels" . | nindent 4 }}


### PR DESCRIPTION
## Description
From commit https://github.com/metal-stack/gardener-extension-backup-s3/commit/0ec8551cae8920451822b1734fa6b57e1b484b2d
This PR fixes a bug where the `rbac-runtime` template was referencing the wrong `ServiceAccountName`.

- The `ClusterRoleBinding` in `rbac-runtime.yaml` pointed to `{{ include "name" . }}` instead of `{{ include "name" . }}-runtime`.
- This mismatch caused RBAC bindings not to work properly, because the `Deployment` and `ServiceAccount` were using a different name.

Changes in this PR:
- Updated `rbac-runtime.yaml` to correctly use `{{ include "name" . }}-runtime`.
- Updated `deployment.yaml` to reference the corrected ServiceAccount.
- Updated `serviceaccount.yaml` to create the ServiceAccount with `-runtime` suffix.

With these changes, the `Deployment`, `ServiceAccount`, and `ClusterRoleBinding` are now consistent.

## Release Notes

```NOTEWORTHY
Bugfix: `rbac-runtime` had a wrong ServiceAccount reference.  
Now the ServiceAccount, Deployment, and ClusterRoleBinding consistently use the `-runtime` suffix.
